### PR TITLE
Add checkbox options for teaching methods

### DIFF
--- a/css/oneweek.css
+++ b/css/oneweek.css
@@ -190,3 +190,36 @@ input {
     left:  calc(var(--teacherLeft) * 1px);
     top:  calc(var(--teacherTop) * 1px + 4 * var(--datumDiffTop) * 1px);
 }
+
+label {
+    font-family: Calibri, sans-serif;
+}
+
+.checkbox1 {
+    position: absolute;
+    left: 1730px;
+    top: 550px;
+    display: flex;
+    align-items: center;
+}
+.checkbox2 {
+    position: absolute;
+    left: 1730px;
+    top: 575px;
+    display: flex;
+    align-items: center;
+}
+.checkbox3 {
+    position: absolute;
+    left: 1730px;
+    top: 620px;
+    display: flex;
+    align-items: center;
+}
+.checkbox4 {
+    position: absolute;
+    left: 1730px;
+    top: 645px;
+    display: flex;
+    align-items: center;
+}

--- a/index.php
+++ b/index.php
@@ -5,6 +5,7 @@ spl_autoload_register(function ($class) {
     include 'class/' . $class . '.php';
 });
 
+$options= array('Frontalunterricht','Projektarbeit','Gruppenarbeit','Selbstlernphase');
 //nur zum Testen
 //echo '<pre>';
 //print_r($_POST);

--- a/view/oneweek.php
+++ b/view/oneweek.php
@@ -63,6 +63,17 @@
         <div id="lesson9"><input name="lesson[]" type="text" style="width: 1200px;"
                                   value="<?php
                                   echo $lesson[4]->getPmContent(); ?>"></div>
+
+        <!-- Module -->
+                <?php
+                foreach($options as $index => $option) {
+                    echo "<div id=\"FormOfInstruction" . ($index + 1) . "\" class=\"checkbox" . ($index + 1) . "\">";
+                    echo "<input type=\"checkbox\" name=\"checkbox[]\" value=\"" . $option . "\">";
+                    echo "<label for=\"FormOfInstruction\">" . $option . "</label>";
+                    echo "</div>";
+                }
+                ?>
+
         <!-- Dozenten -->
         <div id="teacher1"><input type="text" name="teacher[]" value="<?php
             echo $teacher; ?>"></div>


### PR DESCRIPTION
Added a feature for instructors to check available teaching methods: Frontalunterricht, Projektarbeit, Gruppenarbeit, Selbstlernphase. Defined the styling for the checkboxes in onweek.css. Modified view on oneweek.php to display the checkboxes.